### PR TITLE
fix: manage BrokenPipeError thrown by MessageBus.connect()

### DIFF
--- a/src/bluetooth_adapters/__init__.py
+++ b/src/bluetooth_adapters/__init__.py
@@ -46,7 +46,7 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
         bus = await MessageBus(
             bus_type=BusType.SYSTEM, negotiate_unix_fd=True
         ).connect()
-    except FileNotFoundError as ex:
+    except (FileNotFoundError, BrokenPipeError) as ex:
         _LOGGER.debug("Dbus not available: %s", ex)
         return {}
     msg = Message(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,6 +38,22 @@ async def test_get_bluetooth_adapters_connect_fails():
 
 
 @pytest.mark.asyncio
+async def test_get_bluetooth_adapters_connect_broken_pipe():
+    class MockMessageBus:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self):
+            raise BrokenPipeError
+
+        async def call(self):
+            return None
+
+    with patch("bluetooth_adapters.MessageBus", MockMessageBus):
+        assert await get_bluetooth_adapters() == []
+
+
+@pytest.mark.asyncio
 async def test_get_bluetooth_adapters_no_call_return():
     class MockMessageBus:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
With Home Assistant 2022.8.7 (and also 2022.8.2) I get:
```
hass[345]: 2022-08-27 18:00:52.289 ERROR (MainThread) [homeassistant.setup] Error during setup of component bluetooth
hass[345]: Traceback (most recent call last):
hass[345]:   File "/usr/lib/python3.10/site-packages/homeassistant/setup.py", line 235, in _async_setup_component
hass[345]:     result = await task
hass[345]:   File "/usr/lib/python3.10/site-packages/homeassistant/components/bluetooth/__init__.py", line 244, in async_setup
hass[345]:     elif await _async_has_bluetooth_adapter():
hass[345]:   File "/usr/lib/python3.10/site-packages/homeassistant/components/bluetooth/__init__.py", line 224, in _async_has_bluetooth_adapter
hass[345]:     return bool(await async_get_bluetooth_adapters())
hass[345]:   File "/usr/lib/python3.10/site-packages/homeassistant/components/bluetooth/util.py", line 19, in async_get_bluetooth_adapters
hass[345]:     adapters = await get_bluetooth_adapters()
hass[345]:   File "/var/lib/hass/deps/lib/python3.10/site-packages/bluetooth_adapters/__init__.py", line 21, in get_bluetooth_adapters
hass[345]:     bus = await MessageBus(
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 175, in connect
hass[345]:     self._stream.flush()
hass[345]:   File "/usr/lib/python3.10/socket.py", line 723, in write
hass[345]:     return self._sock.send(b)
hass[345]: BrokenPipeError: [Errno 32] Broken pipe
hass[345]: 2022-08-27 18:00:53.072 ERROR (SyncWorker_0) [homeassistant] Error doing job: Future exception was never retrieved
hass[345]: Traceback (most recent call last):
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 158, in on_hello
hass[345]:     raise err
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 365, in _message_reader
hass[345]:     if self._unmarshaller.unmarshall():
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/_private/unmarshaller.py", line 304, in unmarshall
hass[345]:     self._unmarshall()
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/_private/unmarshaller.py", line 243, in _unmarshall
hass[345]:     self.read(16, prefetch=True)
hass[345]:   File "/usr/lib/python3.10/site-packages/dbus_next/_private/unmarshaller.py", line 91, in read
hass[345]:     raise EOFError()
hass[345]: EOFError
```

This is on a `Shenzhen Amediatech Technology Co., Ltd X96 Max` running `5.18.1-1-aarch64-ARCH` (Arch Linux ARM).
It has an `AP6356S` Bluetooth + wifi combo but I don't have bluetooth enabled (only bluez-libs are installed - none of the following is installed: bluez with the daemon, bluez-utils and bluez-tools).

Home Assistant still uses `bluetooth-adapters` version 0.1.3 but with the unit test I am able to reproduce the same issue on the latest version.

I think adding a fix in the `bluetooth-adapters` project is the right way. This is the first time I am troubleshooting (and trying to fix) Home Assistant though.