### PR TITLE
fix: handle ConnectionRefusedError

### DIFF
--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -78,6 +78,17 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
             "DBus connection broken: %s; try restarting " "`bluetooth` and `dbus`", ex
         )
         return {}
+    except ConnectionRefusedError as ex:
+        if is_docker_env():
+            _LOGGER.debug(
+                "DBus connection refused: %s; try restarting "
+                "`bluetooth`, `dbus`, and finally the docker container",
+                ex,
+            )
+        _LOGGER.debug(
+            "DBus connection refused: %s; try restarting " "`bluetooth` and `dbus`", ex
+        )
+        return {}
     msg = Message(
         destination="org.bluez",
         path="/",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,6 +27,18 @@ async def test_get_bluetooth_adapters_file_not_found():
 
 
 @pytest.mark.asyncio
+async def test_get_bluetooth_adapters_connection_refused():
+    """Test get_bluetooth_adapters with connection refused."""
+
+    class MockMessageBus:
+        def __init__(self, *args, **kwargs):
+            raise ConnectionRefusedError
+
+    with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
+        assert await get_bluetooth_adapters() == []
+
+
+@pytest.mark.asyncio
 async def test_get_bluetooth_adapters_connect_fails():
     class MockMessageBus:
         def __init__(self, *args, **kwargs):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,6 +39,24 @@ async def test_get_bluetooth_adapters_connection_refused():
 
 
 @pytest.mark.asyncio
+async def test_get_bluetooth_adapters_connect_refused_docker():
+    class MockMessageBus:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def connect(self):
+            raise ConnectionRefusedError
+
+        async def call(self):
+            return None
+
+    with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus), patch(
+        "bluetooth_adapters.dbus.is_docker_env", return_value=True
+    ):
+        assert await get_bluetooth_adapters() == []
+
+
+@pytest.mark.asyncio
 async def test_get_bluetooth_adapters_connect_fails():
     class MockMessageBus:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes
```
2022-09-26 00:34:47.797 ERROR (MainThread) [homeassistant.setup] Error during setup of component bluetooth
Traceback (most recent call last):
  File "/root/home-assistant/homeassistant/setup.py", line 235, in _async_setup_component
    result = await task
  File "/root/home-assistant/homeassistant/components/bluetooth/__init__.py", line 284, in async_setup
    await manager.async_setup()
  File "/root/home-assistant/homeassistant/components/bluetooth/manager.py", line 220, in async_setup
    history = await async_load_history_from_system()
  File "/root/home-assistant/homeassistant/components/bluetooth/util.py", line 31, in async_load_history_from_system
    await bluez_dbus.load()
  File "/root/home-assistant/venv/lib/python3.9/site-packages/bluetooth_adapters/__init__.py", line 31, in load
    self._managed_objects = await get_dbus_managed_objects()
  File "/root/home-assistant/venv/lib/python3.9/site-packages/bluetooth_adapters/dbus.py", line 49, in get_dbus_managed_objects
    results = await _get_dbus_managed_objects()
  File "/root/home-assistant/venv/lib/python3.9/site-packages/bluetooth_adapters/dbus.py", line 55, in _get_dbus_managed_objects
    bus = await MessageBus(
  File "/root/home-assistant/venv/lib/python3.9/site-packages/dbus_fast/aio/message_bus.py", line 162, in __init__
    super().__init__(bus_address, bus_type, ProxyObject)
  File "/root/home-assistant/venv/lib/python3.9/site-packages/dbus_fast/message_bus.py", line 98, in __init__
    self._setup_socket()
  File "/root/home-assistant/venv/lib/python3.9/site-packages/dbus_fast/message_bus.py", line 635, in _setup_socket
    raise err
  File "/root/home-assistant/venv/lib/python3.9/site-packages/dbus_fast/message_bus.py", line 608, in _setup_socket
    self._sock.connect(filename)
ConnectionRefusedError: [Errno 111] Connection refused
```