### PR TITLE
fix: ensure timeouts work with py3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ python = "^3.9"
 Sphinx = {version = ">=5,<7", optional = true}
 sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = ">=0.18,<2.1", optional = true}
-async-timeout = ">=4.0.2"
+async-timeout = {version = ">=3.0.0", python = "<3.11"}
 dbus-fast = ">=1.21.0"
 bleak = ">=0.15.1"
 usb-devices = ">=0.4.1"

--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -6,11 +6,11 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
-import async_timeout
 from dbus_fast import BusType, Message, MessageType, unpack_variants
 from dbus_fast.aio import MessageBus
 
 from .history import AdvertisementHistory, load_history_from_managed_objects
+from .util import asyncio_timeout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
         member="GetManagedObjects",
     )
     try:
-        async with async_timeout.timeout(REPLY_TIMEOUT):
+        async with asyncio_timeout(REPLY_TIMEOUT):
             reply = await bus.call(msg)
     except EOFError as ex:
         _LOGGER.debug("DBus connection closed: %s", ex)

--- a/src/bluetooth_adapters/systems/linux.py
+++ b/src/bluetooth_adapters/systems/linux.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 import aiohttp
-import async_timeout
 from mac_vendor_lookup import AsyncMacLookup
 from usb_devices import BluetoothDevice, NotAUSBDeviceError
 
@@ -15,6 +14,7 @@ from ..const import UNIX_DEFAULT_BLUETOOTH_ADAPTER
 from ..dbus import BlueZDBusObjects
 from ..history import AdvertisementHistory
 from ..models import AdapterDetails
+from ..util import asyncio_timeout
 from .linux_hci import get_adapters_from_hci
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class LinuxAdapters(BluetoothAdapters):
         ):
             # We don't care if this fails since it only
             # improves the data we get.
-            async with async_timeout.timeout(3):
+            async with asyncio_timeout(3):
                 await self._mac_vendor_lookup.load_vendors()
 
     def _async_get_vendor(self, mac_address: str) -> str | None:

--- a/src/bluetooth_adapters/util.py
+++ b/src/bluetooth_adapters/util.py
@@ -1,6 +1,8 @@
 """Utils."""
 from __future__ import annotations
 
+import sys
+
 from .const import DEFAULT_ADDRESS
 from .models import (
     ADAPTER_PRODUCT,
@@ -8,6 +10,11 @@ from .models import (
     ADAPTER_VENDOR_ID,
     AdapterDetails,
 )
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # noqa: F401
+else:
+    from asyncio import timeout as asyncio_timeout  # noqa: F401
 
 
 def adapter_human_name(adapter: str, address: str) -> str:


### PR DESCRIPTION
async_timeout < 4.0.3 did not work correctly with py3.11, we now use asyncio.timeout on py3.11