### PR TITLE
fix: handle missing hci devices when enumerating adapters

### DIFF
--- a/src/bluetooth_adapters/systems/linux.py
+++ b/src/bluetooth_adapters/systems/linux.py
@@ -116,15 +116,18 @@ class LinuxAdapters(BluetoothAdapters):
                 elif isinstance(device, UARTBluetoothDevice):
                     uart_device = device.uart_device
                     if uart_device is None:
-                        manufacturer = aiooui.get_vendor(mac_address)
-                    elif mac_address == EMPTY_MAC_ADDRESS:
-                        manufacturer = uart_device.manufacturer
+                        if mac_address != EMPTY_MAC_ADDRESS:
+                            manufacturer = aiooui.get_vendor(mac_address)
                     else:
-                        manufacturer = (
-                            aiooui.get_vendor(mac_address) or uart_device.manufacturer
-                        )
-                    if uart_device is not None:
                         product = uart_device.product
+
+                        if mac_address == EMPTY_MAC_ADDRESS:
+                            manufacturer = uart_device.manufacturer
+                        else:
+                            manufacturer = (
+                                aiooui.get_vendor(mac_address)
+                                or uart_device.manufacturer
+                            )
 
                 adapters[adapter] = AdapterDetails(
                     address=mac_address,

--- a/src/bluetooth_adapters/systems/linux.py
+++ b/src/bluetooth_adapters/systems/linux.py
@@ -98,8 +98,9 @@ class LinuxAdapters(BluetoothAdapters):
                 manufacturer = None
                 vendor_id: str | None = None
                 product_id: str | None = None
-                if isinstance(device, USBBluetoothDevice):
-                    usb_device = device.usb_device
+                if isinstance(device, USBBluetoothDevice) and (
+                    usb_device := device.usb_device
+                ):
                     if mac_address != EMPTY_MAC_ADDRESS and (
                         usb_device is None
                         or usb_device.vendor_id == usb_device.manufacturer
@@ -112,8 +113,9 @@ class LinuxAdapters(BluetoothAdapters):
                     product = usb_device.product
                     vendor_id = usb_device.vendor_id
                     product_id = usb_device.product_id
-                elif isinstance(device, UARTBluetoothDevice):
-                    uart_device = device.uart_device
+                elif isinstance(device, UARTBluetoothDevice) and (
+                    uart_device := device.uart_device
+                ):
                     if mac_address == EMPTY_MAC_ADDRESS:
                         manufacturer = uart_device.manufacturer
                     else:
@@ -121,6 +123,8 @@ class LinuxAdapters(BluetoothAdapters):
                             aiooui.get_vendor(mac_address) or uart_device.manufacturer
                         )
                     product = uart_device.product
+                elif mac_address != EMPTY_MAC_ADDRESS:
+                    manufacturer = aiooui.get_vendor(mac_address)
 
                 adapters[adapter] = AdapterDetails(
                     address=mac_address,

--- a/src/bluetooth_adapters/systems/linux.py
+++ b/src/bluetooth_adapters/systems/linux.py
@@ -98,9 +98,8 @@ class LinuxAdapters(BluetoothAdapters):
                 manufacturer = None
                 vendor_id: str | None = None
                 product_id: str | None = None
-                if isinstance(device, USBBluetoothDevice) and (
-                    usb_device := device.usb_device
-                ):
+                if isinstance(device, USBBluetoothDevice):
+                    usb_device = device.usb_device
                     if mac_address != EMPTY_MAC_ADDRESS and (
                         usb_device is None
                         or usb_device.vendor_id == usb_device.manufacturer
@@ -108,23 +107,24 @@ class LinuxAdapters(BluetoothAdapters):
                         or usb_device.manufacturer == "Unknown"
                     ):
                         manufacturer = aiooui.get_vendor(mac_address)
-                    else:
+                    elif usb_device is not None:
                         manufacturer = usb_device.manufacturer
-                    product = usb_device.product
-                    vendor_id = usb_device.vendor_id
-                    product_id = usb_device.product_id
-                elif isinstance(device, UARTBluetoothDevice) and (
-                    uart_device := device.uart_device
-                ):
-                    if mac_address == EMPTY_MAC_ADDRESS:
+                    if usb_device is not None:
+                        product = usb_device.product
+                        vendor_id = usb_device.vendor_id
+                        product_id = usb_device.product_id
+                elif isinstance(device, UARTBluetoothDevice):
+                    uart_device = device.uart_device
+                    if uart_device is None:
+                        manufacturer = aiooui.get_vendor(mac_address)
+                    elif mac_address == EMPTY_MAC_ADDRESS:
                         manufacturer = uart_device.manufacturer
                     else:
                         manufacturer = (
                             aiooui.get_vendor(mac_address) or uart_device.manufacturer
                         )
-                    product = uart_device.product
-                elif mac_address != EMPTY_MAC_ADDRESS:
-                    manufacturer = aiooui.get_vendor(mac_address)
+                    if uart_device is not None:
+                        product = uart_device.product
 
                 adapters[adapter] = AdapterDetails(
                     address=mac_address,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 404, in _async_setup_component
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 235, in async_setup
    await manager.async_setup()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/manager.py", line 133, in async_setup
    await super().async_setup()
  File "src/habluetooth/manager.py", line 262, in async_setup
  File "src/habluetooth/manager.py", line 212, in _async_refresh_adapters
  File "/usr/local/lib/python3.12/site-packages/bluetooth_adapters/systems/linux.py", line 123, in adapters
    product = uart_device.product
              ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'product'
```