### PR TITLE
fix: handle AuthError while probing for adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ build_command = "pip install poetry && poetry build"
 [tool.pytest.ini_options]
 addopts = "-v -Wdefault --cov=bluetooth_adapters --cov-report=term-missing:skip-covered"
 pythonpath = ["src"]
+log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_mode = "auto"
+log_cli = "true"
+log_level = "NOTSET"
 
 [tool.coverage.run]
 branch = true

--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -103,7 +103,7 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
     try:
         bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
     except AuthError as ex:
-        _LOGGER.debug(
+        _LOGGER.warning(
             "DBus authentication error; make sure the DBus socket "
             "is available and the user has the correct permissions: %s",
             ex,

--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -11,12 +11,12 @@ try:
     from dbus_fast.aio import MessageBus
 except (AttributeError, ImportError):
     # dbus_fast is not available on Windows
-    AuthError = None
-    BusType = None
-    Message = None
-    MessageType = None
-    unpack_variants = None
-    MessageBus = None
+    AuthError = None  # pragma: no cover
+    BusType = None  # pragma: no cover
+    Message = None  # pragma: no cover
+    MessageType = None  # pragma: no cover
+    unpack_variants = None  # pragma: no cover
+    MessageBus = None  # pragma: no cover
 
 
 from .history import AdvertisementHistory, load_history_from_managed_objects


### PR DESCRIPTION
In https://github.com/home-assistant/core/issues/116776 the user had a core install where the bus socket exists, and was accessable, but the user lacked permission to access the dbus socket.  

Make this non-fatal and log a warning