### PR TITLE
fix: semantic_release version update + update poetry-core version for build-system to >=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pytest-asyncio = "^0.25.3"
 
 [tool.semantic_release]
 branch = "main"
-version_toml = ["pyproject.toml:tool.poetry.version"]
+version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/bluetooth_adapters/__init__.py:__version__"]
 build_command = "pip install poetry && poetry build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Followup to #199

The version key wasn't probably updated in `pyproject.toml` which resulted in `0.21.2` not being uploaded to PyPI.
https://pypi.org/project/bluetooth-adapters/

Also update the `poetry-core` version for `build-system` to require at least `2.0`.