### PR TITLE
fix: pypi upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - test
       - lint
       - commitlint
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -83,8 +86,17 @@ jobs:
       # - Update version in code
       # - Create git tag
       # - Create GitHub release
-      # - Publish to PyPI
       - name: Python Semantic Release
+        id: release
         uses: python-semantic-release/python-semantic-release@v9.17.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
+      - name: Upload Github Release Assets
+        uses: python-semantic-release/publish-action@v9.17.0
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
Even though the last CI run successfully created the `0.21.3` tag, no release files were uploaded to PyPI.
https://github.com/Bluetooth-Devices/bluetooth-adapters/actions/runs/13137668273/job/36656979158
https://pypi.org/project/bluetooth-adapters/

Add the missing CI steps according to the `python-semantic-release` documentation.
https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html#common-workflow-example

> [!NOTE]
> This requires trusted publisher to be setup.
> https://docs.pypi.org/trusted-publishers/adding-a-publisher/