### PR TITLE
fix: ensure DBus connection is always closed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ allow_untyped_defs = true
 module = "docs.*"
 ignore_errors = true
 
+[tool.ruff]
+target-version = "py39"
+
 [build-system]
 requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -109,7 +109,7 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
     with ExitStack() as stack:
         try:
             bus = MessageBus(bus_type=BusType.SYSTEM)
-            stack.push(bus.disconnect)
+            stack.callback(bus.disconnect)
             await bus.connect()
         except AuthError as ex:
             _LOGGER.warning(

--- a/src/bluetooth_adapters/dbus.py
+++ b/src/bluetooth_adapters/dbus.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack
 from functools import cache
 from pathlib import Path
 from typing import Any
+import asyncio
 
 try:
     from dbus_fast import AuthError, BusType, Message, MessageType, unpack_variants
@@ -163,7 +164,7 @@ async def _get_dbus_managed_objects() -> dict[str, Any]:
         except EOFError as ex:
             _LOGGER.debug("DBus connection closed: %s", ex)
             return {}
-        except TimeoutError:
+        except asyncio.TimeoutError:
             _LOGGER.debug(
                 "Dbus timeout waiting for reply to GetManagedObjects; try restarting "
                 "`bluetooth` and `dbus`"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -325,6 +325,9 @@ async def test_get_bluetooth_adapters_no_wrong_return():
                 ),
             )
 
+        def disconnect(self):
+            pass
+
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_bluetooth_adapters() == []
 
@@ -357,6 +360,9 @@ async def test_get_bluetooth_adapters_correct_return_valid_message():
                 ),
             )
 
+        def disconnect(self):
+            pass
+
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_bluetooth_adapters() == ["hci0", "hci1"]
 
@@ -388,6 +394,9 @@ async def test_get_dbus_managed_objects():
                     )
                 ),
             )
+
+        def disconnect(self):
+            pass
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_dbus_managed_objects() == {
@@ -477,6 +486,9 @@ async def test_BlueZDBusObjects():
                     )
                 ),
             )
+
+        def disconnect(self):
+            pass
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         bluez = BlueZDBusObjects()
@@ -706,6 +718,9 @@ async def test_get_adapters_linux():
                     )
                 ),
             )
+
+        def disconnect(self):
+            pass
 
     class MockUSBDevice(USBDevice):
         def __init__(self, *args, **kwargs):
@@ -988,6 +1003,9 @@ async def test_get_adapters_linux_device_listed_before_adapter():
                     )
                 ),
             )
+
+        def disconnect(self):
+            pass
 
     class MockUSBDevice(USBDevice):
         def __init__(self, *args, **kwargs):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -113,7 +113,7 @@ async def test_get_bluetooth_adapters_connect_refused_docker():
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with (
@@ -139,7 +139,7 @@ async def test_get_bluetooth_adapters_connect_fails():
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
@@ -162,7 +162,7 @@ async def test_get_bluetooth_adapters_connect_fails_docker():
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with (
@@ -188,7 +188,7 @@ async def test_get_bluetooth_adapters_connect_broken_pipe():
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
@@ -211,7 +211,7 @@ async def test_get_bluetooth_adapters_connect_broken_pipe_docker():
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with (
@@ -232,14 +232,12 @@ async def test_get_bluetooth_adapters_connect_eof_error():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(), call=AsyncMock(side_effect=EOFError)
-            )
+            pass
 
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             raise EOFError
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
@@ -257,12 +255,12 @@ async def test_get_bluetooth_adapters_no_call_return():
             pass
 
         async def connect(self):
-            return AsyncMock(disconnect=MagicMock(), call=AsyncMock())
+            pass
 
         def disconnect(self):
             pass
 
-        async def call(self):
+        async def call(self, *args, **kwargs):
             return None
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
@@ -283,10 +281,10 @@ async def test_get_bluetooth_adapters_times_out():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(side_effect=_stall),
-            )
+            pass
+
+        async def call(self, *args, **kwargs):
+            await _stall(*args)
 
         def disconnect(self):
             pass
@@ -309,24 +307,22 @@ async def test_get_bluetooth_adapters_no_wrong_return():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/org/bluez/hci0": "",
-                                "/org/bluez/hci1": "",
-                                "/org/bluez/hci1/any": "",
-                            }
-                        ],
-                        message_type="wrong",
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/org/bluez/hci0": "",
+                        "/org/bluez/hci1": "",
+                        "/org/bluez/hci1/any": "",
+                    }
+                ],
+                message_type="wrong",
+            )
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_bluetooth_adapters() == []
@@ -343,25 +339,23 @@ async def test_get_bluetooth_adapters_correct_return_valid_message():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0": {},
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci1/any": {},
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0": {},
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci1/any": {},
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
+            )
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_bluetooth_adapters() == ["hci0", "hci1"]
@@ -378,25 +372,23 @@ async def test_get_dbus_managed_objects():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0": {},
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci1/any": {},
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0": {},
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci1/any": {},
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
+            )
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         assert await get_dbus_managed_objects() == {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,6 +110,9 @@ async def test_get_bluetooth_adapters_connect_refused_docker():
         async def connect(self):
             raise ConnectionRefusedError
 
+        def disconnect(self):
+            pass
+
         async def call(self):
             return None
 
@@ -133,6 +136,9 @@ async def test_get_bluetooth_adapters_connect_fails():
         async def connect(self):
             raise FileNotFoundError
 
+        def disconnect(self):
+            pass
+
         async def call(self):
             return None
 
@@ -152,6 +158,9 @@ async def test_get_bluetooth_adapters_connect_fails_docker():
 
         async def connect(self):
             raise FileNotFoundError
+
+        def disconnect(self):
+            pass
 
         async def call(self):
             return None
@@ -176,6 +185,9 @@ async def test_get_bluetooth_adapters_connect_broken_pipe():
         async def connect(self):
             raise BrokenPipeError
 
+        def disconnect(self):
+            pass
+
         async def call(self):
             return None
 
@@ -195,6 +207,9 @@ async def test_get_bluetooth_adapters_connect_broken_pipe_docker():
 
         async def connect(self):
             raise BrokenPipeError
+
+        def disconnect(self):
+            pass
 
         async def call(self):
             return None
@@ -221,6 +236,9 @@ async def test_get_bluetooth_adapters_connect_eof_error():
                 disconnect=MagicMock(), call=AsyncMock(side_effect=EOFError)
             )
 
+        def disconnect(self):
+            pass
+
         async def call(self):
             raise EOFError
 
@@ -240,6 +258,9 @@ async def test_get_bluetooth_adapters_no_call_return():
 
         async def connect(self):
             return AsyncMock(disconnect=MagicMock(), call=AsyncMock())
+
+        def disconnect(self):
+            pass
 
         async def call(self):
             return None
@@ -266,6 +287,9 @@ async def test_get_bluetooth_adapters_times_out():
                 disconnect=MagicMock(),
                 call=AsyncMock(side_effect=_stall),
             )
+
+        def disconnect(self):
+            pass
 
     with (
         patch.object(bluetooth_adapters_dbus, "REPLY_TIMEOUT", 0),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,9 +110,6 @@ async def test_get_bluetooth_adapters_connect_refused_docker():
         async def connect(self):
             raise ConnectionRefusedError
 
-        def disconnect(self):
-            pass
-
         async def call(self):
             return None
 
@@ -136,9 +133,6 @@ async def test_get_bluetooth_adapters_connect_fails():
         async def connect(self):
             raise FileNotFoundError
 
-        def disconnect(self):
-            pass
-
         async def call(self):
             return None
 
@@ -158,9 +152,6 @@ async def test_get_bluetooth_adapters_connect_fails_docker():
 
         async def connect(self):
             raise FileNotFoundError
-
-        def disconnect(self):
-            pass
 
         async def call(self):
             return None
@@ -185,9 +176,6 @@ async def test_get_bluetooth_adapters_connect_broken_pipe():
         async def connect(self):
             raise BrokenPipeError
 
-        def disconnect(self):
-            pass
-
         async def call(self):
             return None
 
@@ -207,9 +195,6 @@ async def test_get_bluetooth_adapters_connect_broken_pipe_docker():
 
         async def connect(self):
             raise BrokenPipeError
-
-        def disconnect(self):
-            pass
 
         async def call(self):
             return None
@@ -236,9 +221,6 @@ async def test_get_bluetooth_adapters_connect_eof_error():
                 disconnect=MagicMock(), call=AsyncMock(side_effect=EOFError)
             )
 
-        def disconnect(self):
-            pass
-
         async def call(self):
             raise EOFError
 
@@ -258,9 +240,6 @@ async def test_get_bluetooth_adapters_no_call_return():
 
         async def connect(self):
             return AsyncMock(disconnect=MagicMock(), call=AsyncMock())
-
-        def disconnect(self):
-            pass
 
         async def call(self):
             return None
@@ -287,9 +266,6 @@ async def test_get_bluetooth_adapters_times_out():
                 disconnect=MagicMock(),
                 call=AsyncMock(side_effect=_stall),
             )
-
-        def disconnect(self):
-            pass
 
     with (
         patch.object(bluetooth_adapters_dbus, "REPLY_TIMEOUT", 0),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from platform import system
 from typing import Any
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from bleak.backends.device import BLEDevice
@@ -1075,201 +1075,202 @@ async def test_get_adapters_linux_uart():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:04",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
+            pass
+
+        def disconnect(self):
+            pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:04",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci2": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:00:00:00:00:00",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci3": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:05",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/any": {},
+                        "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -78,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
                                 },
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci2": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:00:00:00:00:00",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
                                 },
-                                "/org/bluez/hci3": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:05",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -100,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
                                 },
-                                "/org/bluez/hci1/any": {},
-                                "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -78,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
                                 },
-                                "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -100,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
             )
 
     class MockUARTDevice(UARTDevice):
@@ -1365,115 +1366,116 @@ async def test_get_adapters_linux_no_usb_device():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci3": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:04",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
+            pass
+
+        def disconnect(self):
+            pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci3": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:04",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci4": {},
+                        "/org/bluez/hci5/any": {},
+                        "/org/bluez/hci3/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -78,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci3",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
                                 },
-                                "/org/bluez/hci4": {},
-                                "/org/bluez/hci5/any": {},
-                                "/org/bluez/hci3/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -78,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci3",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
                                 },
-                                "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -100,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -100,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
                                 },
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
             )
 
     class NoMfrMockUSBDevice(USBDevice):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -410,77 +410,75 @@ async def test_BlueZDBusObjects():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0": {},
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci1/any": {},
-                                "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -78,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -100,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0": {},
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci1/any": {},
+                        "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -78,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -100,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
+            )
 
     with patch("bluetooth_adapters.dbus.MessageBus", MockMessageBus):
         bluez = BlueZDBusObjects()
@@ -514,205 +512,203 @@ async def test_get_adapters_linux():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:04",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci2": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:00:00:00:00:00",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci3": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:05",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1/any": {},
-                                "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -78,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -100,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:04",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci2": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:00:00:00:00:00",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci3": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:05",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/any": {},
+                        "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -78,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -100,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
+            )
 
     class MockUSBDevice(USBDevice):
         def __init__(self, *args, **kwargs):
@@ -799,205 +795,203 @@ async def test_get_adapters_linux_device_listed_before_adapter():
             pass
 
         async def connect(self):
-            return AsyncMock(
-                disconnect=MagicMock(),
-                call=AsyncMock(
-                    return_value=MagicMock(
-                        body=[
-                            {
-                                "/other": {},
-                                "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -78,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci0": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:04",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1": {},
-                                "/org/bluez/hci2": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:00:00:00:00:00",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci3": {
-                                    "org.bluez.Adapter1": {
-                                        "Address": "00:1A:7D:DA:71:05",
-                                        "AddressType": "public",
-                                        "Alias": "homeassistant",
-                                        "Class": 2883584,
-                                        "Discoverable": False,
-                                        "DiscoverableTimeout": 180,
-                                        "Discovering": True,
-                                        "Modalias": "usb:v1D6Bp0246d053F",
-                                        "Name": "homeassistant",
-                                        "Pairable": False,
-                                        "PairableTimeout": 0,
-                                        "Powered": True,
-                                        "Roles": ["central", "peripheral"],
-                                        "UUIDs": [
-                                            "0000110e-0000-1000-8000-00805f9b34fb",
-                                            "0000110a-0000-1000-8000-00805f9b34fb",
-                                            "00001200-0000-1000-8000-00805f9b34fb",
-                                            "0000110b-0000-1000-8000-00805f9b34fb",
-                                            "00001108-0000-1000-8000-00805f9b34fb",
-                                            "0000110c-0000-1000-8000-00805f9b34fb",
-                                            "00001800-0000-1000-8000-00805f9b34fb",
-                                            "00001801-0000-1000-8000-00805f9b34fb",
-                                            "0000180a-0000-1000-8000-00805f9b34fb",
-                                            "00001112-0000-1000-8000-00805f9b34fb",
-                                        ],
-                                    },
-                                    "org.bluez.GattManager1": {},
-                                    "org.bluez.LEAdvertisingManager1": {
-                                        "ActiveInstances": 0,
-                                        "SupportedIncludes": [
-                                            "tx-power",
-                                            "appearance",
-                                            "local-name",
-                                        ],
-                                        "SupportedInstances": 5,
-                                    },
-                                    "org.bluez.Media1": {},
-                                    "org.bluez.NetworkServer1": {},
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                                "/org/bluez/hci1/any": {},
-                                "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
-                                    "org.freedesktop.DBus.Introspectable": {},
-                                    "org.bluez.Device1": {
-                                        "Address": "54:D2:72:AB:35:95",
-                                        "AddressType": "public",
-                                        "Name": "Nuki_1EAB3595",
-                                        "Alias": "Nuki_1EAB3595",
-                                        "Paired": False,
-                                        "Trusted": False,
-                                        "Blocked": False,
-                                        "LegacyPairing": False,
-                                        "RSSI": -100,
-                                        "Connected": False,
-                                        "UUIDs": [],
-                                        "Adapter": "/org/bluez/hci0",
-                                        "ManufacturerData": {
-                                            "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
-                                        },
-                                        "ServicesResolved": False,
-                                        "AdvertisingFlags": {
-                                            "__type": "<class 'bytearray'>",
-                                            "repr": "bytearray(b'\\x06')",
-                                        },
-                                    },
-                                    "org.freedesktop.DBus.Properties": {},
-                                },
-                            }
-                        ],
-                        message_type=MessageType.METHOD_RETURN,
-                    )
-                ),
-            )
+            pass
 
         def disconnect(self):
             pass
+
+        async def call(self, *args, **kwargs):
+            return MagicMock(
+                body=[
+                    {
+                        "/other": {},
+                        "/org/bluez/hci0/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -78,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci0": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:04",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1": {},
+                        "/org/bluez/hci2": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:00:00:00:00:00",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci3": {
+                            "org.bluez.Adapter1": {
+                                "Address": "00:1A:7D:DA:71:05",
+                                "AddressType": "public",
+                                "Alias": "homeassistant",
+                                "Class": 2883584,
+                                "Discoverable": False,
+                                "DiscoverableTimeout": 180,
+                                "Discovering": True,
+                                "Modalias": "usb:v1D6Bp0246d053F",
+                                "Name": "homeassistant",
+                                "Pairable": False,
+                                "PairableTimeout": 0,
+                                "Powered": True,
+                                "Roles": ["central", "peripheral"],
+                                "UUIDs": [
+                                    "0000110e-0000-1000-8000-00805f9b34fb",
+                                    "0000110a-0000-1000-8000-00805f9b34fb",
+                                    "00001200-0000-1000-8000-00805f9b34fb",
+                                    "0000110b-0000-1000-8000-00805f9b34fb",
+                                    "00001108-0000-1000-8000-00805f9b34fb",
+                                    "0000110c-0000-1000-8000-00805f9b34fb",
+                                    "00001800-0000-1000-8000-00805f9b34fb",
+                                    "00001801-0000-1000-8000-00805f9b34fb",
+                                    "0000180a-0000-1000-8000-00805f9b34fb",
+                                    "00001112-0000-1000-8000-00805f9b34fb",
+                                ],
+                            },
+                            "org.bluez.GattManager1": {},
+                            "org.bluez.LEAdvertisingManager1": {
+                                "ActiveInstances": 0,
+                                "SupportedIncludes": [
+                                    "tx-power",
+                                    "appearance",
+                                    "local-name",
+                                ],
+                                "SupportedInstances": 5,
+                            },
+                            "org.bluez.Media1": {},
+                            "org.bluez.NetworkServer1": {},
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                        "/org/bluez/hci1/any": {},
+                        "/org/bluez/hci1/dev_54_D2_72_AB_35_95": {
+                            "org.freedesktop.DBus.Introspectable": {},
+                            "org.bluez.Device1": {
+                                "Address": "54:D2:72:AB:35:95",
+                                "AddressType": "public",
+                                "Name": "Nuki_1EAB3595",
+                                "Alias": "Nuki_1EAB3595",
+                                "Paired": False,
+                                "Trusted": False,
+                                "Blocked": False,
+                                "LegacyPairing": False,
+                                "RSSI": -100,
+                                "Connected": False,
+                                "UUIDs": [],
+                                "Adapter": "/org/bluez/hci0",
+                                "ManufacturerData": {
+                                    "76": b"\\x02\\x15\\xa9.\\xe2\\x00U\\x01\\x11\\xe4\\x91l\\x08\\x00 \\x0c\\x9af\\x1e\\xab5\\x95\\xc4"
+                                },
+                                "ServicesResolved": False,
+                                "AdvertisingFlags": {
+                                    "__type": "<class 'bytearray'>",
+                                    "repr": "bytearray(b'\\x06')",
+                                },
+                            },
+                            "org.freedesktop.DBus.Properties": {},
+                        },
+                    }
+                ],
+                message_type=MessageType.METHOD_RETURN,
+            )
 
     class MockUSBDevice(USBDevice):
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The `_get_dbus_managed_objects` function did not guarantee the closing of the DBus connection if an exception occurred after connection. This could lead to a resource leak.

This commit refactors the function to use a `try...finally` block, ensuring that `bus.disconnect()` is always called, making the connection handling more robust.