### PR TITLE
feat: support additional adapter details

### DIFF
--- a/src/bluetooth_adapters/models.py
+++ b/src/bluetooth_adapters/models.py
@@ -18,6 +18,11 @@ class AdapterDetails(TypedDict, total=False):
     passive_scan: bool
     connection_slots: int | None
     adapter_type: str | None  # "usb", "uart", or None
+    advertise: bool
+    """Whether the adapter supports advertising."""
+
+    powered: bool
+    """Whether the adapter is powered on."""
 
 
 ADAPTER_ADDRESS: Final = "address"

--- a/src/bluetooth_adapters/systems/linux.py
+++ b/src/bluetooth_adapters/systems/linux.py
@@ -94,6 +94,8 @@ class LinuxAdapters(BluetoothAdapters):
                         vendor_id=None,
                         product_id=None,
                         adapter_type=None,  # Unknown for hci-only adapters
+                        advertise=hci_details["advertise"],
+                        powered=hci_details["powered"],
                     )
             adapter_details = self._bluez.adapter_details
             for adapter, details in adapter_details.items():
@@ -106,6 +108,7 @@ class LinuxAdapters(BluetoothAdapters):
                 vendor_id: str | None = None
                 product_id: str | None = None
                 adapter_type: str | None = None
+                powered = adapter1["Powered"]
                 if isinstance(device, USBBluetoothDevice):
                     adapter_type = "usb"
                     usb_device = device.usb_device
@@ -149,6 +152,8 @@ class LinuxAdapters(BluetoothAdapters):
                     vendor_id=vendor_id,
                     product_id=product_id,
                     adapter_type=adapter_type,
+                    advertise="org.bluez.LEAdvertisingManager1" in details,
+                    powered=powered,
                 )
             self._adapters = adapters
         return self._adapters

--- a/src/bluetooth_adapters/systems/linux_hci.py
+++ b/src/bluetooth_adapters/systems/linux_hci.py
@@ -20,6 +20,9 @@ HCI_MAX_DEV = 16
 HCIGETDEVLIST = 0x800448D2  # _IOR('H', 210, int)
 HCIGETDEVINFO = 0x800448D3  # _IOR('H', 211, int)
 
+HCI_UP = 0  # HCI device flag
+LMP_LE = 0x40  # LMP capabilities
+
 
 class hci_dev_req(ctypes.Structure):
     _fields_ = [("dev_id", ctypes.c_uint16), ("dev_opt", ctypes.c_uint32)]
@@ -94,6 +97,10 @@ def get_adapters_from_hci() -> dict[int, dict[str, Any]]:
             info = {str(k): getattr(dev, k) for k, *v_ in dev._fields_}
             info["bdaddr"] = str(info["bdaddr"])
             info["name"] = info["name"].decode()
+            info["powered"] = bool(info["flags"] & (1 << HCI_UP))
+            info["advertise"] = bool(
+                info["features"][4] & LMP_LE
+            )  # assume advertising supported if device supports LE
             out[int(dev.dev_id)] = info
     except OSError as error:
         _LOGGER.debug("Error while getting HCI devices: %s", error)

--- a/src/bluetooth_adapters/systems/macos.py
+++ b/src/bluetooth_adapters/systems/macos.py
@@ -21,6 +21,8 @@ class MacOSAdapters(BluetoothAdapters):
                 vendor_id="Unknown",
                 product_id="Unknown",
                 adapter_type=None,  # Unknown for macOS
+                advertise=True,
+                powered=True,
             )
         }
 

--- a/src/bluetooth_adapters/systems/windows.py
+++ b/src/bluetooth_adapters/systems/windows.py
@@ -23,6 +23,8 @@ class WindowsAdapters(BluetoothAdapters):
                 vendor_id="Unknown",
                 product_id="Unknown",
                 adapter_type=None,  # Unknown for Windows
+                advertise=True,
+                powered=True,
             )
         }
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -760,6 +760,8 @@ async def test_get_adapters_linux():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
             "hci2": {
                 "address": "00:00:00:00:00:00",
@@ -771,6 +773,8 @@ async def test_get_adapters_linux():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
             "hci3": {
                 "address": "00:1A:7D:DA:71:05",
@@ -782,6 +786,8 @@ async def test_get_adapters_linux():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
         }
 
@@ -1050,6 +1056,8 @@ async def test_get_adapters_linux_device_listed_before_adapter():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
             "hci2": {
                 "address": "00:00:00:00:00:00",
@@ -1061,6 +1069,8 @@ async def test_get_adapters_linux_device_listed_before_adapter():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
             "hci3": {
                 "address": "00:1A:7D:DA:71:05",
@@ -1072,6 +1082,8 @@ async def test_get_adapters_linux_device_listed_before_adapter():
                 "sw_version": "18.7.0",
                 "vendor_id": "0a12",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
         }
 
@@ -1348,6 +1360,8 @@ async def test_get_adapters_linux_uart():
                 "sw_version": "18.7.0",
                 "vendor_id": None,
                 "adapter_type": "uart",
+                "advertise": True,
+                "powered": True,
             },
             "hci2": {
                 "address": "00:00:00:00:00:00",
@@ -1359,6 +1373,8 @@ async def test_get_adapters_linux_uart():
                 "sw_version": "18.7.0",
                 "vendor_id": None,
                 "adapter_type": "uart",
+                "advertise": True,
+                "powered": True,
             },
             "hci3": {
                 "address": "00:1A:7D:DA:71:05",
@@ -1370,6 +1386,8 @@ async def test_get_adapters_linux_uart():
                 "sw_version": "18.7.0",
                 "vendor_id": None,
                 "adapter_type": "uart",
+                "advertise": True,
+                "powered": True,
             },
         }
 
@@ -1546,6 +1564,8 @@ async def test_get_adapters_linux_no_usb_device():
                 "passive_scan": False,
                 "sw_version": "18.7.0",
                 "adapter_type": "usb",
+                "advertise": True,
+                "powered": True,
             },
         }
 
@@ -1585,8 +1605,18 @@ async def test_get_adapters_linux_hci_only_adapter():
         patch(
             "bluetooth_adapters.systems.linux.get_adapters_from_hci",
             return_value={
-                5: {"name": "hci5", "bdaddr": "00:1A:7D:DA:71:13"},
-                9: {"name": "hci9", "bdaddr": "00:00:00:00:00:00"},
+                5: {
+                    "name": "hci5",
+                    "bdaddr": "00:1A:7D:DA:71:13",
+                    "powered": True,
+                    "advertise": True,
+                },
+                9: {
+                    "name": "hci9",
+                    "bdaddr": "00:00:00:00:00:00",
+                    "powered": False,
+                    "advertise": False,
+                },
             },
         ),
         patch(
@@ -1607,6 +1637,8 @@ async def test_get_adapters_linux_hci_only_adapter():
                 "vendor_id": None,
                 "product_id": None,
                 "adapter_type": None,
+                "powered": True,
+                "advertise": True,
             },
             "hci9": {
                 "address": "00:00:00:00:00:00",
@@ -1618,6 +1650,8 @@ async def test_get_adapters_linux_hci_only_adapter():
                 "vendor_id": None,
                 "product_id": None,
                 "adapter_type": None,
+                "powered": False,
+                "advertise": False,
             },
         }
 
@@ -1643,6 +1677,8 @@ async def test_get_adapters_macos():
                 "vendor_id": "Unknown",
                 "product_id": "Unknown",
                 "adapter_type": None,
+                "advertise": True,
+                "powered": True,
             }
         }
 
@@ -1668,6 +1704,8 @@ async def test_get_adapters_windows():
                 "vendor_id": "Unknown",
                 "product_id": "Unknown",
                 "adapter_type": None,
+                "advertise": True,
+                "powered": True,
             }
         }
 
@@ -1702,6 +1740,8 @@ def test_adapter_model():
             "product": "Unknown Windows Model",
             "vendor_id": "Unknown",
             "product_id": "Unknown",
+            "advertise": True,
+            "powered": True,
         }
     )
     assert adapter_model(windows_details) == "Unknown Windows Model"
@@ -1715,6 +1755,8 @@ def test_adapter_model():
             "hw_version": "usb:v1D6Bp0246d053F",
             "passive_scan": False,
             "sw_version": "18.7.0",
+            "advertise": True,
+            "powered": True,
         }
     )
     assert adapter_model(linux_details) == "Bluetooth 4.0 USB Adapter (0a12:0001)"

--- a/tests/test_linux_hci.py
+++ b/tests/test_linux_hci.py
@@ -24,13 +24,16 @@ from bluetooth_adapters.systems.linux_hci import (
 
 
 def _make_ioctl(
-    devices: dict[int, tuple[str, list[int]]],
+    devices: dict[int, tuple[str, list[int]]]
+    | dict[int, tuple[str, list[int], int, list[int]]],
 ) -> Callable[[int, int, Any], int]:
     """Build a fake ``fcntl.ioctl`` that populates the ctypes buffers.
 
-    ``devices`` maps a device id to ``(name, bdaddr_bytes)`` where
-    ``bdaddr_bytes`` is the 6-byte little-endian address as stored by the
-    kernel (``bdaddr_t.__str__`` reverses it when rendering).
+    ``devices`` maps a device id to ``(name, bdaddr_bytes)`` or
+    ``(name, bdaddr_bytes, flags, features)`` where ``bdaddr_bytes`` is the
+    6-byte little-endian address as stored by the kernel (``bdaddr_t.__str__``
+    reverses it when rendering) and ``features`` is the 8-byte LMP feature
+    mask. When ``flags``/``features`` are omitted they default to zero.
     """
 
     def ioctl(_fd: int, request: int, arg: Any) -> int:
@@ -39,9 +42,13 @@ def _make_ioctl(
             for i, dev_id in enumerate(devices):
                 arg.dev_req[i].dev_id = dev_id
         elif request == HCIGETDEVINFO:
-            name, bdaddr = devices[arg.dev_id]
+            entry = devices[arg.dev_id]
+            name, bdaddr = entry[0], entry[1]
             arg.name = name.encode()
             arg.bdaddr.b = (ctypes.c_uint8 * 6)(*bdaddr)
+            if len(entry) == 4:
+                arg.flags = entry[2]
+                arg.features = (ctypes.c_uint8 * 8)(*entry[3])
         return 0
 
     return ioctl
@@ -67,6 +74,48 @@ def test_get_adapters_from_hci_parses_devices() -> None:
     assert out[0]["bdaddr"] == "00:1A:7D:DA:71:04"
     assert out[1]["name"] == "hci1"
     assert out[1]["bdaddr"] == "00:1A:7D:DA:71:05"
+
+
+def test_get_adapters_from_hci_parses_powered_and_advertise() -> None:
+    """Powered (HCI_UP) and advertise (LMP_LE) bits are decoded correctly."""
+    devices = {
+        # Powered, LE capable: HCI_UP bit 0 set, features[4] has LMP_LE (0x40).
+        0: (
+            "hci0",
+            [0x04, 0x71, 0xDA, 0x7D, 0x1A, 0x00],
+            0x01,
+            [0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00],
+        ),
+        # Down, no LE: flags and features all zero.
+        1: (
+            "hci1",
+            [0x05, 0x71, 0xDA, 0x7D, 0x1A, 0x00],
+            0x00,
+            [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        ),
+        # Powered but no LE; also exercises other flag bits being ignored.
+        2: (
+            "hci2",
+            [0x06, 0x71, 0xDA, 0x7D, 0x1A, 0x00],
+            0xFF,
+            [0xFF, 0xFF, 0xFF, 0xFF, 0xBF, 0xFF, 0xFF, 0xFF],
+        ),
+    }
+    fake_fcntl = MagicMock()
+    fake_fcntl.ioctl.side_effect = _make_ioctl(devices)
+
+    with (
+        patch.object(linux_hci, "fcntl", fake_fcntl),
+        patch.object(linux_hci, "socket"),
+    ):
+        out = get_adapters_from_hci()
+
+    assert out[0]["powered"] is True
+    assert out[0]["advertise"] is True
+    assert out[1]["powered"] is False
+    assert out[1]["advertise"] is False
+    assert out[2]["powered"] is True
+    assert out[2]["advertise"] is False
 
 
 def test_get_adapters_from_hci_empty_when_no_devices() -> None:


### PR DESCRIPTION
I've added the following adapter details to make capability checks easier, or filter for powered devices only.

- `advertise`: Whether the adapter supports advertising.

   On Linux, determined by checking for the
   `org.bluez.LEAdvertisingManager1` interface.

   On Linux (HCI), determined by checking the HCI device features,
   assumed `True` if device supports LE.

   On MacOS and Windows assumed to be `True`.

- `powered`: Whether the adapter is powered.

   On Linux, determined by checking the `Powered` property.

   On Linux (HCI), determined by checking the HCI device info flags.

   On MacOs and Windows assumed to be `True`.